### PR TITLE
Use jQuery from django-formset-js

### DIFF
--- a/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/lower_thirds.html
+++ b/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/lower_thirds.html
@@ -7,7 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         <title>{{ request.event.name }} lower thirds</title>
         {% compress js %}
-            <script src="{% static "vendored/jquery-3.1.1.js" %}"></script>
+            <script src="{% static "js/jquery.js" %}"></script>
         {% endcompress %}
         <script src="{% static "pretalx_broadcast_tools/generic.js" %}"></script>
         <script src="{% static "pretalx_broadcast_tools/lower_thirds.js" %}"></script>


### PR DESCRIPTION
pretalx-main isn't shipping jQuery anymore (as of today / next release), but our dependency django-formset-js still includes it, so you can pull it in from there instead.