### PR TITLE
Remove unused templatetag

### DIFF
--- a/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/lower_thirds.html
+++ b/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/lower_thirds.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load compress %}
 <!DOCTYPE html>
 <html>
     <head>

--- a/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/room_info.html
+++ b/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/room_info.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load compress %}
 <!DOCTYPE html>
 <html>
     <head>

--- a/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/room_timer.html
+++ b/pretalx_broadcast_tools/templates/pretalx_broadcast_tools/room_timer.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load compress %}
 <!DOCTYPE html>
 <html>
     <head>


### PR DESCRIPTION
Pretalx is about to drop the compressor library, and the templatetag was not in use anyways.