### PR TITLE
Cut down startup time

### DIFF
--- a/pretalx_broadcast_tools/views/qr.py
+++ b/pretalx_broadcast_tools/views/qr.py
@@ -1,7 +1,5 @@
 from xml.etree import ElementTree
 
-import qrcode
-import qrcode.image.svg
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.safestring import mark_safe
@@ -9,6 +7,13 @@ from django.views import View
 
 
 def _make_svg_response(url):
+    # Deferred so that the plugin's URLconf import (which loads at app startup)
+    # doesn't drag the qrcode package — and the PIL it pulls in — into every
+    # web process. The cost (~65 ms in pretalx startup measurements) only
+    # materialises when somebody actually hits the QR endpoint.
+    import qrcode  # noqa: PLC0415
+    import qrcode.image.svg  # noqa: PLC0415
+
     image = qrcode.make(url, image_factory=qrcode.image.svg.SvgImage)
     svg_data = mark_safe(ElementTree.tostring(image.get_image()).decode())
     return HttpResponse(svg_data, content_type="image/svg+xml")

--- a/pretalx_broadcast_tools/views/voctomix_export.py
+++ b/pretalx_broadcast_tools/views/voctomix_export.py
@@ -3,15 +3,21 @@ from django.views import View
 from pretalx.common.text.path import safe_filename
 from pretalx.common.views.mixins import EventPermissionRequired
 
-from pretalx_broadcast_tools.management.commands.export_voctomix_lower_thirds import (
-    get_export_targz_path,
-)
-
 
 class BroadcastToolsLowerThirdsVoctomixDownloadView(EventPermissionRequired, View):
     permission_required = "schedule.list_schedule"
 
     def get(self, request, *args, **kwargs):
+        # Deferred so that the plugin's URLconf import doesn't drag in the
+        # management command's heavy module-level dependencies (PIL.Image,
+        # ImageDraw, ImageFont, plus the whole pretalx.agenda.html_export
+        # subtree, which itself unconditionally imports django.test.Client).
+        # That's ~100+ ms saved off every web-process startup, and the cost
+        # only materialises when someone hits the download endpoint.
+        from pretalx_broadcast_tools.management.commands.export_voctomix_lower_thirds import (  # noqa: PLC0415
+            get_export_targz_path,
+        )
+
         targz_path = get_export_targz_path(self.request.event)
         if not targz_path.exists():
             raise Http404()


### PR DESCRIPTION
Moving these imports inline drops pretalx startup times by ~180ms, which is roughly 10% depending on other plugins installed. Not all that noticeable on the server, but makes development smoother :)