### PR TITLE
Fix automatic exporter update logic

### DIFF
--- a/pretalx_broadcast_tools/tasks.py
+++ b/pretalx_broadcast_tools/tasks.py
@@ -65,7 +65,7 @@ def task_periodic_voctomix_export(*, event_slug):
 @receiver(periodic_task)
 def periodic_event_services(sender, **kwargs):
     two_days_ago = now().date() - timedelta(days=2)
-    for event in Event.objects.all().filter(date_to__lt=two_days_ago):
+    for event in Event.objects.all().filter(date_to__gte=two_days_ago):
         with scope(event=event):
             if not event.settings.broadcast_tools_lower_thirds_export_voctomix or not event.current_schedule:
                 continue


### PR DESCRIPTION
Old behaviour: automatically export if the event is > 2 days in the past. New behaviour: Automatically export if the event is in the future or up to 2 days in the past.